### PR TITLE
Fix config example typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This is an example:
 ```json
 {
     "os_user": "kevin",
-    "use_private_id": true,
+    "use_private_ip": true,
     "regions": ["eu-central-1", "us-east-1"],
     "key_file_path_private": "/home/example/.ssh/somekey",
     "key_file_path_public": "/home/example/.ssh/somekey.pub",


### PR DESCRIPTION
Changed use_private_id to use_private_ip in example on the readme. Noticed it was inconsistent with the code.