### PR TITLE
Add a CLI argument to enable SSM Session Manager SSH proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,20 @@ With sshaws, in the best case, connecting to your instances will look like this:
 
 ![](sshaws.gif)
 
+Support for [SSH connections through AWS Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html) is also included. This allows you to connect to EC2 instances without Internet access (provided there's a VPC endpoint available) or whose security group does no allow ingress on port 22.
+
 ## Requirements
 
 - python3 and pip
 - configured aws credentials and rights to connect to the instance
 - instance needs to support ec2-instance-connect (AWS AMIs support that + you can install it on your servers)
 - public (or private) IP needs to be reachable
+
+Changes to requirements if using SSM tunnel:
+
+- credentials with rights to call `aws ssm start-session` on ressource *document/AWS-StartSSHSession*
+- instance needs to be running the SSM Agent version 2.3.672.0 or later (inc. an appropriate IAM role)
+- instance needs to be reachable through Internet or an SSM VPC endpoint
 
 ## Installation
 
@@ -65,6 +73,7 @@ This is an example:
 {
     "os_user": "kevin",
     "use_private_ip": true,
+    "use_ssm": false,
     "regions": ["eu-central-1", "us-east-1"],
     "key_file_path_private": "/home/example/.ssh/somekey",
     "key_file_path_public": "/home/example/.ssh/somekey.pub",

--- a/sshaws
+++ b/sshaws
@@ -35,6 +35,7 @@ default_use_private_ip = conf.get('use_private_ip', False)
 # Backwards compat due to typo with versions <= 0.3.2
 if not default_use_private_ip:
     default_use_private_ip = conf.get('use_private_id', False)
+default_use_ssm = conf.get('use_ssm', False)
 default_forward_agent = conf.get('forward_agent', False)
 default_aliases_dict = conf.get('aliases', {})
 
@@ -47,6 +48,7 @@ parser.add_argument('--private-key-file', type=argparse.FileType('r'),
                     default=default_key_file_path_private, help=f'Private key file to use for connection. Default: {default_key_file_path_private}')
 parser.add_argument('--regions', type=str, nargs='+', default=default_regions, help=f'Look for the instance in the given regions. Default: {default_regions}')
 parser.add_argument('--use-private-ip', action='store_true', help=f'Use private IP even if public IP is available. sshaws will use private ip automatically, if no public IP is available.', default=default_use_private_ip)
+parser.add_argument('--use-ssm', action='store_true', help=f'Use AWS System Manager Session Manager to proxy the connection', default=default_use_ssm)
 parser.add_argument('-a', '--forward-agent', action='store_true', help=f'Enables ssh agent forwarding', default=default_forward_agent)
 args = parser.parse_args()
 
@@ -89,5 +91,7 @@ if not ip_to_connect_to:
 command_list = ['ssh']
 if args.forward_agent:
     command_list.append('-A')
-command_list.extend(['-i', args.private_key_file.name, f'{args.os_user}@{ip_to_connect_to}'])
+if args.use_ssm:
+    command_list.extend(['-o', 'ProxyCommand=sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters \'portNumber=%p\'"'])
+command_list.extend(['-i', args.private_key_file.name, f'{args.os_user}@{args.instance_id if args.use_ssm else ip_to_connect_to}'])
 subprocess.run(command_list)


### PR DESCRIPTION
Hey, I needed to use [SSM Session Manager to "proxy" the SSH connection](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html), so I added a flag to enable it.

In case you feel this change is useful, here's a pull request!